### PR TITLE
[skip changelog] Update the JDK from v14 to v16 and prefer the official OpenJDK over AdoptOpenJDK

### DIFF
--- a/.github/scripts/linux.sh
+++ b/.github/scripts/linux.sh
@@ -3,7 +3,7 @@
 set -o errexit -o pipefail -o nounset
 IFS=$'\t\n'
 
-FX="https://gluonhq.com/download/javafx-14-jmods-linux"
+FX="https://gluonhq.com/download/javafx-16-jmods-linux"
 
 CURRENT_DIR=$(pwd)
 echo "Current dir: $CURRENT_DIR"
@@ -16,7 +16,7 @@ echo "Will build Conduktor $VERSION"
 echo "Downloading JavaFX Jmods..."
 curl -sLO $FX
 unzip -oq javafx-*-jmods-linux
-FX_MODS_PATH="./javafx-jmods-14"
+FX_MODS_PATH="./javafx-jmods-16"
 
 CONDUKTOR_DISTRIBUTION_PATH="$(pwd)/conduktor-$VERSION"
 

--- a/.github/scripts/macos.sh
+++ b/.github/scripts/macos.sh
@@ -3,7 +3,7 @@
 set -o errexit -o pipefail -o nounset
 IFS=$'\t\n'
 
-FX="https://gluonhq.com/download/javafx-14-jmods-mac"
+FX="https://gluonhq.com/download/javafx-16-jmods-mac"
 
 CURRENT_DIR=$(pwd)
 echo "Current dir: $CURRENT_DIR"
@@ -39,8 +39,8 @@ echo "Downloading JavaFX Jmods..."
 curl -sLO $FX
 unzip -oq javafx-*-jmods-mac
 # cleanup
-rm -f javafx-14-jmods-mac
-FX_MODS_PATH="./javafx-jmods-14"
+rm -f javafx-16-jmods-mac
+FX_MODS_PATH="./javafx-jmods-16"
 
 echo "Building custom JRE..."
 CUSTOM_JRE_NAME="runtime"

--- a/.github/scripts/windows.sh
+++ b/.github/scripts/windows.sh
@@ -3,7 +3,7 @@
 set -o errexit -o pipefail -o nounset -x
 IFS=$'\t\n'
 
-FX="https://gluonhq.com/download/javafx-14-jmods-windows"
+FX="https://gluonhq.com/download/javafx-16-jmods-windows"
 
 CURRENT_DIR=$(pwd)
 echo "Current dir: $CURRENT_DIR"
@@ -16,7 +16,7 @@ echo "Will build Conduktor $VERSION"
 echo "Downloading JavaFX Jmods..."
 curl -sLO $FX
 unzip -oq javafx-*-jmods-windows
-FX_MODS_PATH="./javafx-jmods-14"
+FX_MODS_PATH="./javafx-jmods-16"
 
 CONDUKTOR_DISTRIBUTION_PATH="$(pwd)/conduktor-$VERSION"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: joschi/setup-jdk@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: openjdk14
+          distribution: 'zulu'
+          java-version: '11'
+          java-package: jdk #+fx
       - name: Fetch Conduktor sources
         run: |
           git clone --single-branch --branch ${{ github.event.client_payload.tag }} --depth 1 https://osef:${{secrets.GH_BUILD_TOKEN}}@github.com/conduktor/conduktor-desktop.git
@@ -72,10 +74,12 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: joschi/setup-jdk@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: openjdk14
+          distribution: 'zulu'
+          java-version: '11'
+          java-package: jdk #+fx
       - name: Fetch Conduktor sources
         run: |
           git clone --single-branch --branch ${{ github.event.client_payload.tag }} --depth 1 https://osef:${{secrets.GH_BUILD_TOKEN}}@github.com/conduktor/conduktor-desktop.git
@@ -126,10 +130,12 @@ jobs:
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: joschi/setup-jdk@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: openjdk14
+          distribution: 'zulu'
+          java-version: '11'
+          java-package: jdk #+fx
       - name: Fetch Conduktor sources
         run: |
           git clone --single-branch --branch ${{ github.event.client_payload.tag }} --depth 1 https://osef:${{secrets.GH_BUILD_TOKEN}}@github.com/conduktor/conduktor-desktop.git
@@ -183,9 +189,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: joschi/setup-jdk@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: openjdk14
+          distribution: 'zulu'
+          java-version: '11'
+          java-package: jdk #+fx
 
       - name: Download built distribution
         uses: actions/download-artifact@v1
@@ -222,9 +231,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: joschi/setup-jdk@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: openjdk14
+          distribution: 'zulu'
+          java-version: '11'
+          java-package: jdk #+fx
 
       - name: Download built distribution
         uses: actions/download-artifact@v1
@@ -256,9 +268,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: joschi/setup-jdk@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: openjdk14
+          distribution: 'zulu'
+          java-version: '11'
+          java-package: jdk #+fx
 
       - name: Download built distribution
         uses: actions/download-artifact@v1

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -19,10 +19,12 @@ jobs:
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: joschi/setup-jdk@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: openjdk14
+          distribution: 'zulu'
+          java-version: '11'
+          java-package: jre #+fx
       - name: Fetch Conduktor sources
         run: |
           git clone --single-branch --branch ${{ github.event.client_payload.tag }} --depth 1 https://osef:${{secrets.GH_BUILD_TOKEN}}@github.com/conduktor/conduktor-desktop.git
@@ -76,9 +78,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: joschi/setup-jdk@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: openjdk14
+          distribution: 'zulu'
+          java-version: '11'
+          java-package: jre #+fx
 
       - name: Download built distribution
         uses: actions/download-artifact@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,161 @@
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+


### PR DESCRIPTION
because of bug:

```
Exception in thread "main" java.lang.RuntimeException: java.lang.UnsatisfiedLinkError: C:\Program Files\Conduktor\runtime\bin\glass.dll: Can't find dependent libraries
        at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.startup(Unknown Source)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.startup(Unknown Source)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.startup(Unknown Source)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.startToolkit(Unknown Source)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.launchApplication1(Unknown Source)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.lambda$launchApplication$2(Unknown Source)
```

Caused by https://github.com/adoptium/temurin-build/issues/878